### PR TITLE
Example unit test for spots srvice, run with npm test

### DIFF
--- a/karma-shim.js
+++ b/karma-shim.js
@@ -7,9 +7,11 @@ require('ts-helpers');
 
 require('zone.js/dist/zone');
 require('zone.js/dist/long-stack-trace-zone');
-require('zone.js/dist/jasmine-patch');
 require('zone.js/dist/async-test');
 require('zone.js/dist/fake-async-test');
+require('zone.js/dist/sync-test');
+require('zone.js/dist/proxy'); // since zone.js 0.6.15
+require('zone.js/dist/jasmine-patch'); // put here since zone.js 0.6.14
 
 /*
  Ok, this is kinda crazy. We can use the the context method on
@@ -30,7 +32,6 @@ appContext.keys().forEach(appContext);
 // Select BrowserDomAdapter.
 // see https://github.com/AngularClass/angular2-webpack-starter/issues/124
 // Somewhere in the test setup
-var testing = require('@angular/core/testing');
-var browser = require('@angular/platform-browser-dynamic/testing');
-
-testing.setBaseTestProviders(browser.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS, browser.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);
+// var testing = require('@angular/core/testing');
+// var browser = require('@angular/platform-browser-dynamic/testing');
+// testing.setBaseTestProviders(browser.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS, browser.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      { pattern: './karma-shim.js', watched: false }
+      { pattern: './karma-shim.js', watched: false },
     ],
 
     // list of files to exclude
@@ -75,7 +75,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: true,
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
@@ -83,7 +83,7 @@ module.exports = function (config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true
+    singleRun: false
   };
 
   config.set(_config);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/turf": "^3.5.32",
     "angularfire2": "^2.0.0-beta.8",
     "core-js": "^2.4.1",
+    "es6-shim": "^0.35.3",
     "firebase": "^3.6.9",
     "hammerjs": "^2.0.8",
     "mapbox-gl": "^0.32.1",

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,6 +1,6 @@
 export * from './geolocation.service';
 export * from './maplocation.service';
-export * from './spots.service';
+export * from './spots/spots.service';
 export * from './distance.service';
 export * from './rulesinfo.service';
 export * from './editspotstate.service';

--- a/src/app/services/spots/spots.service.spec.ts
+++ b/src/app/services/spots/spots.service.spec.ts
@@ -1,0 +1,17 @@
+import { SpotsService } from './spots.service';
+import { AngularFire } from 'angularfire2';
+
+describe('when spots service is called', () => {
+    
+    it('should call for database value and save it', () => {
+        let mockAngularFire : any = {
+            database: {
+                list : jasmine.createSpy('list').and.returnValue(3)
+            }
+        };
+        
+        let serviceToTest = new SpotsService(mockAngularFire as AngularFire);
+        expect(mockAngularFire.database.list).toHaveBeenCalledTimes(1);
+        expect(serviceToTest.get()).toEqual(3);
+    });
+});

--- a/src/app/services/spots/spots.service.ts
+++ b/src/app/services/spots/spots.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs/Observable';
 import { Position } from '~/util';
 
 // If the user is offline, use this data:
-const data = require('./data/spots$.json');
+const data = require('../data/spots$.json');
 
 @Injectable()
 export class SpotsService {


### PR DESCRIPTION
I added some missing packages, fixed setup configurations.  Now you can run unit tests with `npm test`

I also added a simple test for spots service that uses a mock injected service to verify that the function isn called, and I can get the result from the service.